### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "ndstrim"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "bincode",
  "clap",


### PR DESCRIPTION
Had some issues while trying to package this in NixOS/nixpkgs:

```
error: the lock file /build/source/Cargo.lock needs to be updated but --frozen was passed to prevent this
If you want to try to generate the lock file without accessing the network, remove the --frozen flag and use --offline instead.
```

This should fix it.