### PR TITLE
Use Thin LTO instead of Full LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ clap = { version = "4.6.1", features = ["derive"] }
 crc = "3.4.0"
 
 [profile.release]
-lto = true
+lto = "thin"
 strip = true

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For a debug build, run:
 cargo b
 ```
 
-For a release build, which produces an optimized and stripped binary with full LTO, run:
+For a release build, which produces an optimized and stripped binary with Thin LTO, run:
 
 ```bash
 cargo b --release


### PR DESCRIPTION
Hello!

I have proposed this change as FLTO is much slower in LLVM than GCC, as it doesn't use partitioning and has limited parallelism.

Thin LTO on the other hand is much faster even than GCC FLTO, and usually loses 0-2% performance, which nobody would notice in normal usage.

This halves the compile time on my machine on a release build. I know, this is seems pointless to add as the absolute time is still low (30s or so) but it shouldn't really take so long for a program of such scale.

Thanks!